### PR TITLE
feat: add README files and dirs for products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# ADR
+
+This repository contains [architectural decision records](https://adr.github.io/) (ADRs) for Dash.
+
+## Contributing
+
+PRs accepted.
+
+## License
+
+[MIT](./LICENSE) © Dash Core Group, Inc.

--- a/engineering/clients/javascript/README.md
+++ b/engineering/clients/javascript/README.md
@@ -1,0 +1,3 @@
+# Dash Core ADRs
+
+This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for JavaScript clients.

--- a/engineering/clients/mobile/README.md
+++ b/engineering/clients/mobile/README.md
@@ -1,0 +1,3 @@
+# Mobile Client ADRs
+
+This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for Dash mobile clients.

--- a/engineering/clients/mobile/android/README.md
+++ b/engineering/clients/mobile/android/README.md
@@ -1,0 +1,3 @@
+# Android Mobile Client ADRs
+
+This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for Dash Android mobile clients.

--- a/engineering/clients/mobile/ios/README.md
+++ b/engineering/clients/mobile/ios/README.md
@@ -1,0 +1,3 @@
+# iOS Mobile Client ADRs
+
+This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for Dash iOS mobile clients.

--- a/engineering/core/README.md
+++ b/engineering/core/README.md
@@ -1,0 +1,3 @@
+# Dash Core ADRs
+
+This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for Dash Core.

--- a/engineering/core/README.md
+++ b/engineering/core/README.md
@@ -1,3 +1,3 @@
 # Dash Core ADRs
 
-This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for Dash Core.
+This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for [Dash Core](https://github.com/dashpay/dash).

--- a/engineering/grovedb/README.md
+++ b/engineering/grovedb/README.md
@@ -1,0 +1,3 @@
+# GroveDB ADRs
+
+This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for [GroveDB](https://github.com/dashevo/grovedb/).

--- a/engineering/platform/README.md
+++ b/engineering/platform/README.md
@@ -1,3 +1,3 @@
 # Dash Platform ADRs
 
-This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for Dash Platform.
+This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for [Dash Platform](https://github.com/dashevo/platform/).

--- a/engineering/platform/README.md
+++ b/engineering/platform/README.md
@@ -1,0 +1,3 @@
+# Dash Platform ADRs
+
+This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for Dash Platform.

--- a/engineering/tenderdash/README.md
+++ b/engineering/tenderdash/README.md
@@ -1,0 +1,3 @@
+# Tenderdash ADRs
+
+This directory contains [architectural decision records](https://adr.github.io/) (ADRs) for [Tenderdash](https://github.com/dashevo/tenderdash/).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Current repository has no structure

## What was done?
<!--- Describe your changes in detail -->
Add an initial `engineering` directory for [ADRs](https://adr.github.io/) that also includes sub-dirs for Core/Platform with some (very) minimal readme files.

Proposed initial directory structure as discussed in recent calls:
```
engineering
└ clients
| └ javascript
| └ mobile
| | └ android
| | └ ios
└ core
└ grovedb
└ platform
└ tenderdash
```